### PR TITLE
added code of conduct from python's website

### DIFF
--- a/code_of_conduct.txt
+++ b/code_of_conduct.txt
@@ -1,0 +1,19 @@
+Python Community Code of Conduct
+
+The Python community is made up of members from around the globe with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences great successes and continued growth. When you're working with members of the community, we encourage you to follow these guidelines which help steer our interactions and strive to keep Python a positive, successful, and growing community.
+
+A member of the Python community is:
+
+Open
+Members of the community are open to collaboration, whether it's on PEPs, patches, problems, or otherwise. We're receptive to constructive comment and criticism, as the experiences and skill sets of other members contribute to the whole of our efforts. We're accepting of all who wish to take part in our activities, fostering an environment where anyone can participate and everyone can make a difference.
+
+Considerate
+Members of the community are considerate of their peers -- other Python users. We're thoughtful when addressing the efforts of others, keeping in mind that often times the labor was completed simply for the good of the community. We're attentive in our communications, whether in person or online, and we're tactful when approaching differing views.
+
+Respectful
+Members of the community are respectful. We're respectful of others, their positions, their skills, their commitments, and their efforts. We're respectful of the volunteer efforts that permeate the Python community. We're respectful of the processes set forth in the community, and we work within them. When we disagree, we are courteous in raising our issues.
+
+Overall, we're good to each other. We contribute to this community not because we have to, but because we want to. If we remember that, these guidelines will come naturally.
+
+Questions/comments/reports? Please write to the Code of Conduct Committee: conduct@python.org. Note: this email address is to the members of the Code of Conduct Committee. Alternatively, you may reach Ewa Jodlowska, Director of Operations, at ewa@python.org.
+


### PR DESCRIPTION
I just shamelessly copied the <b>code of conduct</b>  from the python's website and added it to a txt file as a reference guide.
